### PR TITLE
improve API to the changelog-lib and adding a new generation method to the cmd

### DIFF
--- a/packages/changelog-cmd/bin/changelog_cmd.dart
+++ b/packages/changelog-cmd/bin/changelog_cmd.dart
@@ -70,7 +70,8 @@ ArgResults configureCommandLine(List<String> args) {
 }
 
 ChangelogGenerator configureGenerator(
-    {required String versionName,
+    {required String packageName,
+      required String versionName,
     required String start,
     required String end,
     String fromBranch = "main",
@@ -83,7 +84,7 @@ ChangelogGenerator configureGenerator(
         githubRepo: githubRepository,
         fromBranch: fromBranch);
   }
-  var changelog = ChangelogGenerator(fetcher: fetcher);
+  var changelog = ChangelogGenerator(packageName: packageName, fetcher: fetcher);
   return changelog;
 }
 
@@ -97,11 +98,13 @@ Future<void> main(List<String> arguments) async {
   var end = cmd[pointToEnd] ?? "";
   var format = cmd[changelogFormat];
   var genMethod = cmd[generationMethod];
+  var package = cmd[packageName] ?? '';
 
   var printerMediator = PrinterMediator();
   var generatorMediator = GeneratorMediator();
 
   var generator = configureGenerator(
+    packageName: package,
       versionName: changelogVersion,
       start: start,
       end: end,

--- a/packages/changelog-cmd/lib/method/generator_mediator.dart
+++ b/packages/changelog-cmd/lib/method/generator_mediator.dart
@@ -1,15 +1,16 @@
-import 'package:changelog_cmd/method/header_msg.dart';
-import 'package:changelog_cmd/method/method_generation.dart';
-import 'package:changelog_lib/changelog_lib.dart';
-
 /// Generator mediator contains all the generation method
 /// supported by the changelog command line
 ///
 /// author: https://github.com/vincenzopalazzo
+import 'package:changelog_cmd/method/header_msg.dart';
+import 'package:changelog_cmd/method/metadata_msg.dart';
+import 'package:changelog_cmd/method/method_generation.dart';
+import 'package:changelog_lib/changelog_lib.dart';
 
 class GeneratorMediator {
   final Map<String, MethodGenerator> _methods = {
     "header": HeaderGenerator(),
+    "metadata": MetadataGenerator(),
   };
 
   /// Check if inside the map there is a method generator with the name provided

--- a/packages/changelog-cmd/lib/method/header_msg.dart
+++ b/packages/changelog-cmd/lib/method/header_msg.dart
@@ -1,6 +1,3 @@
-import 'package:changelog_cmd/method/method_generation.dart';
-import 'package:changelog_lib/changelog_lib.dart';
-
 /// Header Msg is the method generator to generate the changelog
 /// from the message header like this example here
 /// https://github.com/invertase/melos/blob/main/packages/melos/CHANGELOG.md
@@ -14,10 +11,16 @@ import 'package:changelog_lib/changelog_lib.dart';
 /// - `docs: message ` to document a new doc addition.
 ///
 /// author: https://github.com/vincenzopalazzo
+import 'package:changelog_cmd/method/method_generation.dart';
+import 'package:changelog_lib/changelog_lib.dart';
 
 class HeaderGenerator extends MethodGenerator {
   @override
-  void apply({required ChangelogGenerator generator}) {
+  void apply(
+      {required ChangelogGenerator generator,
+      String? exactMatchHeader,
+      RegExp? regexHeader,
+      bool strictly = false}) {
     generator.addFilterRule(
         rule: FilterRule(headerExactMatch: "fix:", nameSection: "Fixes"));
     generator.addFilterRule(
@@ -25,5 +28,18 @@ class HeaderGenerator extends MethodGenerator {
             FilterRule(headerExactMatch: "feat:", nameSection: "New Feature"));
     generator.addFilterRule(
         rule: FilterRule(headerExactMatch: "doc:", nameSection: "Docs"));
+
+    generator.addFilterRule(
+        rule: FilterRule(
+            headerExactMatch: "fix(${generator.packageName}):",
+            nameSection: "Fixes"));
+    generator.addFilterRule(
+        rule: FilterRule(
+            headerExactMatch: "feat(${generator.packageName}):",
+            nameSection: "New Feature"));
+    generator.addFilterRule(
+        rule: FilterRule(
+            headerExactMatch: "doc(${generator.packageName}):",
+            nameSection: "Docs"));
   }
 }

--- a/packages/changelog-cmd/lib/method/metadata_msg.dart
+++ b/packages/changelog-cmd/lib/method/metadata_msg.dart
@@ -1,0 +1,68 @@
+/// Metadata MSG is a generation method used
+/// to extract the changelog from a list of commits
+/// with the help of the metadata.
+///
+/// This generation method works with commits that looks like as follows:
+///
+/// ```
+/// graphql: add a new API to refresh the client
+///
+/// Changelog-Add: add a new API to refresh the client
+/// ```
+///
+/// The changelog line are as reported as follow:
+/// - `Changelog-Added`: if the pull request adds a new feature
+/// - `Changelog-Changed`: if a feature has been modified and might require changes on the user side
+/// - `Changelog-Deprecated`: if a feature has been marked for deprecation, but not yet removed
+/// - `Changelog-Fixed`: if a bug has been fixed
+/// - `Changelog-Removed`: if a (previously deprecated) feature has been removed
+/// - `Changelog-Experimental`: if it only affects –enable-experimental-features builds, or experimental- config options.
+///
+/// author: https://github.com/vincenzopalazzo
+import 'package:changelog_cmd/method/method_generation.dart';
+import 'package:changelog_lib/changelog_lib.dart';
+
+class MetadataGenerator extends MethodGenerator {
+  @override
+  void apply(
+      {required ChangelogGenerator generator,
+      String? exactMatchHeader,
+      RegExp? regexHeader,
+      bool strictly = false}) {
+    generator.addFilterRule(
+        rule: FilterRule(
+            nameSection: 'Added',
+            exactMatch: "Changelog-Added",
+            headerExactMatch: exactMatchHeader,
+            regex: regexHeader,
+            strict: strictly));
+    generator.addFilterRule(
+        rule: FilterRule(
+            nameSection: 'Changed',
+            exactMatch: "Changelog-Changed",
+            headerExactMatch: exactMatchHeader,
+            regex: regexHeader,
+            strict: strictly));
+    generator.addFilterRule(
+        rule: FilterRule(
+            nameSection: 'Deprecated',
+            exactMatch: "Changelog-Deprecated",
+            headerExactMatch: exactMatchHeader,
+            regex: regexHeader,
+            strict: strictly));
+    generator.addFilterRule(
+        rule: FilterRule(
+            nameSection: 'Fixed',
+            exactMatch: "Changelog-Fixed",
+            headerExactMatch: exactMatchHeader,
+            regex: regexHeader,
+            strict: strictly));
+    generator.addFilterRule(
+        rule: FilterRule(
+            nameSection: 'Experimental',
+            exactMatch: "Changelog-Experimental",
+            headerExactMatch: exactMatchHeader,
+            regex: regexHeader,
+            strict: strictly));
+  }
+}

--- a/packages/changelog-cmd/lib/method/method_generation.dart
+++ b/packages/changelog-cmd/lib/method/method_generation.dart
@@ -1,11 +1,14 @@
-import 'package:changelog_lib/changelog_lib.dart';
-
 /// Method Generator is the interface to implement different
 /// method generation for the Changelog.
 ///
 /// author: https://github.com/vincenzopalazzo
+import 'package:changelog_lib/changelog_lib.dart';
 
 abstract class MethodGenerator {
   // apply the sequence of rules to the generator
-  void apply({required ChangelogGenerator generator});
+  void apply(
+      {required ChangelogGenerator generator,
+      String? exactMatchHeader,
+      RegExp? regexHeader,
+      bool strictly = false});
 }

--- a/packages/changelog-cmd/pubspec.lock
+++ b/packages/changelog-cmd/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       path: "../changelog-lib"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.0.1-alpha.2"
   charcode:
     dependency: transitive
     description:

--- a/packages/changelog-lib/lib/src/changelog_lib_base.dart
+++ b/packages/changelog-lib/lib/src/changelog_lib_base.dart
@@ -22,10 +22,16 @@ class ChangelogGenerator {
   /// The fetcher that the user decide
   /// to use in order to receive the commit information.
   final GenericFetcher fetcher;
+
+  /// Sequence of rules that need to be satisfied to
+  /// to filter the commits
   final FilterChainOfResponsibility _filterChain =
       FilterChainOfResponsibility();
 
-  ChangelogGenerator({required this.fetcher});
+  /// The name of the package/tool/lib
+  final String packageName;
+
+  ChangelogGenerator({required this.packageName, required this.fetcher});
 
   /// method to add a new filter rule to generate a new section
   /// in the changelog.

--- a/packages/changelog-lib/lib/src/filter_rule/filter_chain.dart
+++ b/packages/changelog-lib/lib/src/filter_rule/filter_chain.dart
@@ -21,7 +21,8 @@ class FilterChainOfResponsibility {
       for (var commit in commits) {
         var change = rule.match(commitInfo: commit);
         if (change != null) {
-          changelogSection.addChange(change: change, authorInfo: commit.author, ref: commit.url);
+          changelogSection.addChange(
+              change: change, authorInfo: commit.author, ref: commit.url);
         }
       }
       changelogSections.add(changelogSection);
@@ -30,7 +31,10 @@ class FilterChainOfResponsibility {
     if (rules.isEmpty) {
       var mainSection = ChangelogSection(sectionName: "General");
       for (var element in commits) {
-        mainSection.addChange(change: element.content.commitHeader, authorInfo: element.author, ref: element.url);
+        mainSection.addChange(
+            change: element.content.commitHeader,
+            authorInfo: element.author,
+            ref: element.url);
       }
       changelogSections.add(mainSection);
     }

--- a/packages/changelog-lib/lib/src/filter_rule/filter_rule.dart
+++ b/packages/changelog-lib/lib/src/filter_rule/filter_rule.dart
@@ -38,12 +38,24 @@ class FilterRule {
   /// of the match it is specified in the commit info
   final RegExp? regex;
 
+  /// If true, The check between header and body need to be strict
+  /// this mean that the check on the header and the body must be
+  /// satisfied.
+  /// if false (as default), if the header it is not matching but
+  /// the body yes, the commit is checked anyway
+  ///
+  /// This is useful when there are packages information on the header
+  /// but this information are not satisfied, but we want add the info
+  /// anyway if the body match!
+  final bool strict;
+
   FilterRule(
       {required this.nameSection,
-        this.exactMatch,
-        this.regex,
+      this.exactMatch,
+      this.regex,
       this.headerExactMatch,
-      this.headerRegex});
+      this.headerRegex,
+      this.strict = false});
 
   /// match is a function that apply the match logic to
   /// return the content to put in the changelog, and
@@ -53,7 +65,7 @@ class FilterRule {
   /// and it is not able to clean the metadata attach to the commit body.
   String? match({required CommitInfo commitInfo}) {
     var headerMatch = _headerMatch(commitInfo: commitInfo);
-    if (headerMatch == null) {
+    if (headerMatch == null && strict) {
       return null;
     }
 

--- a/packages/changelog-lib/lib/src/model/changelog_section.dart
+++ b/packages/changelog-lib/lib/src/model/changelog_section.dart
@@ -16,7 +16,9 @@ class ChangelogSection {
   List<ChangelogItem> get changes => _changes;
 
   /// add a new change made from a commit author in the list of changes.
-  void addChange({required String change, required CommitAuthor authorInfo, String? ref}) {
-    changes.add(ChangelogItem(authorInfo: authorInfo, content: change, ref: ref));
+  void addChange(
+      {required String change, required CommitAuthor authorInfo, String? ref}) {
+    changes
+        .add(ChangelogItem(authorInfo: authorInfo, content: change, ref: ref));
   }
 }

--- a/packages/changelog-lib/test/changelog_lib_test.dart
+++ b/packages/changelog-lib/test/changelog_lib_test.dart
@@ -5,7 +5,8 @@ import 'package:test/scaffolding.dart';
 import 'mock/fetcher_mock.dart';
 
 Future<void> main() async {
-  var generator = ChangelogGenerator(fetcher: FetcherMock());
+  var generator =
+      ChangelogGenerator(packageName: 'test', fetcher: FetcherMock());
 
   group('generating changelog from mock fetcher', () {
     test('Generate from one rules', () async {


### PR DESCRIPTION
To changelog-lib, we add the strict variable to have a better filter method between rules and add the package name to the ChangelogGenerator. 

To changelog-cmd, we add a metadata generator method to improve the usage of metadata inside the commit message and make the commit header more human-friendly.